### PR TITLE
Fix Login and Logout Naming & Their Test

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,6 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   rescue_from CanCan::AccessDenied do |exception|
-    redirect_to signin_path, :alert => exception.message
+    redirect_to login_path, :alert => exception.message
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -11,15 +11,15 @@ class UserSessionsController < ApplicationController
   	@user = current_user
 
   	if @user = login(params[:username], params[:password], params[:remember])
-  		redirect_back_or_to root_path, notice: 'Sign in successful'
+  		redirect_back_or_to root_path, notice: 'Login successful'
   	else
-  		flash.now.alert = 'Sign in failed'
+  		flash.now.alert = 'Login failed'
   		render action: :new
   	end
   end
 
   def destroy
   	logout
-  	redirect_back_or_to root_path, notice: "Signed out!"
+  	redirect_back_or_to root_path, notice: "Logged out successful!"
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,4 +1,6 @@
 class UserSessionsController < ApplicationController
+  load_and_authorize_resource only: [:destroy]
+
   def new
   	if current_user.present?
   		redirect_back_or_to root_path

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,12 +26,12 @@
       <% end %>
 
       <% if current_user %>
-        <%= link_to("Sign Out", :signout, method: :delete) %>
+        <%= link_to("Logout", :logout, method: :delete) %>
         <%= link_to("Edit", edit_user_path(current_user.id)) %>
         <%= link_to("Profile", :myprofile) %>
       <% else %>
         <%= link_to("Sign Up", :signup) %>
-        <%= link_to("Sign in", :signin) %>
+        <%= link_to("Login", :login) %>
       <% end %>
     </header>
 

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,7 +1,7 @@
 <section class="user-form">
-	<h2>Sign In</h2>
+	<h2>Login</h2>
 
-	<%= form_tag user_sessions_path, id: "signin", method: :post do %>
+	<%= form_tag user_sessions_path, id: "login", method: :post do %>
 
 		<div class="form-field">
 			<%= label_tag :username %>
@@ -18,7 +18,7 @@
 		</div>
 		<br>
 		<div class="form-field">
-			<%= submit_tag "Sign In", class: "submit expand"  %>
+			<%= submit_tag "Login", class: "submit expand"  %>
 		</div>
 
 	<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,8 @@ Rails.application.routes.draw do
 
   get 'signup'          => 'users#new',               as: :signup
   get 'myprofile'       => 'users#show',              as: :myprofile
-  get 'signin'          => 'user_sessions#new',       as: :signin
-  delete 'signout'      => 'user_sessions#destroy',   as: :signout
+  get 'login'           => 'user_sessions#new',       as: :login
+  delete 'logout'       => 'user_sessions#destroy',   as: :logout
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -22,41 +22,41 @@ RSpec.feature "Users", type: :feature do
   	end
   end
 
-  describe "sign in process" do
+  describe "login process" do
   	let!(:user) { create(:user) }
 
-  	it "should sign me in" do
-  		visit "/signin"
+  	it "should log me in" do
+  		visit "/login"
 
-  		within "#signin" do
+  		within "#login" do
   			fill_in "Username", with: user.username
   			fill_in "Password", with: "Pass3word:"
   		end
 
-  		click_button "Sign In"
-  		expect(page).to have_content "Sign in successful"
+  		click_button "Login"
+  		expect(page).to have_content "Login successful"
   	end
   end
 
-  describe "sign out process" do
+  describe "logout process" do
   	let!(:user) { create(:user) }
 
-		it "should sign me out" do
+		it "should log me out" do
 			login_user_post(user.username, "Pass3word:")
 
 			visit "/"
-			click_link "Sign Out"
-			expect(page).to have_content "Signed out"	
+			click_link "Logout"
+			expect(page).to have_content "Logged out"	
 		end
 	end
 
 	describe "edit user process" do
 		let(:user) { create(:user) }
 		
-		it "should not be on edit if not sign in" do
+		it "should not be on edit if not login" do
 			visit "/users/#{user.id}/edit"
 
-			expect(current_path).to eq("/signin")
+			expect(current_path).to eq("/login")
 		end
 
 		context "should be able to change" do
@@ -66,6 +66,7 @@ RSpec.feature "Users", type: :feature do
 
 				visit "/"
 				click_link "Edit"
+
 	  		within ".edit_user" do
 	  			fill_in "Username", with: new_username
 	  		end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Users", type: :feature do
   end
 
   describe "login process" do
-  	let!(:user) { create(:user) }
+  	let(:user) { create(:user) }
 
   	it "should log me in" do
   		visit root_url
@@ -41,7 +41,7 @@ RSpec.feature "Users", type: :feature do
   end
 
   describe "logout process" do
-  	let!(:user) { create(:user) }
+  	let(:user) { create(:user) }
 
 		it "should log me out" do
 			login_user_post(user.username, "Pass3word:")

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -4,8 +4,9 @@ require 'capybara/rspec'
 RSpec.feature "Users", type: :feature do
   describe "sign up process" do
   	it "should create a user" do
-  		visit "/signup"
-  		
+  		visit root_url
+      click_link "Sign Up"
+
   		within "#new_user" do
   			user_new_password = "Pass3word:"
 
@@ -26,7 +27,8 @@ RSpec.feature "Users", type: :feature do
   	let!(:user) { create(:user) }
 
   	it "should log me in" do
-  		visit "/login"
+  		visit root_url
+      click_link "Login"
 
   		within "#login" do
   			fill_in "Username", with: user.username
@@ -44,7 +46,7 @@ RSpec.feature "Users", type: :feature do
 		it "should log me out" do
 			login_user_post(user.username, "Pass3word:")
 
-			visit "/"
+			visit root_url
 			click_link "Logout"
 			expect(page).to have_content "Logged out"	
 		end
@@ -64,7 +66,7 @@ RSpec.feature "Users", type: :feature do
 				login_user_post(user.username, "Pass3word:")
 				new_username = Faker::Internet.user_name
 
-				visit "/"
+				visit root_url
 				click_link "Edit"
 
 	  		within ".edit_user" do

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Users", type: :feature do
   describe "login process" do
   	let(:user) { create(:user) }
 
-  	it "should log me in" do
+  	it "should login" do
   		visit root_url
       click_link "Login"
 
@@ -43,7 +43,7 @@ RSpec.feature "Users", type: :feature do
   describe "logout process" do
   	let(:user) { create(:user) }
 
-		it "should log me out" do
+		it "should logout" do
 			login_user_post(user.username, "Pass3word:")
 
 			visit root_url


### PR DESCRIPTION
- Change the name of the sign in & sign out to Login and Logout
- Change the Sign Up, Login & Login to run faster and be more realized
- Add Restitution To Only Log Out User When Login
