### PR TITLE
Fix Posting Not Submitting After Fixing Validation 

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -36,7 +36,7 @@ class PostsController < ApplicationController
     if @post.update_attributes(post_params) 
       redirect_to post_path(params[:id]), notice: "Your post has been updated"
     else
-      flash.now alert = "Error Updating your post"
+      flash.now.alert = "Error Updating your post"
       render :edit
     end
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
 	def index
-		@posts = Post.all
+		@posts = Post.all.order(id: :desc)
 	end
 
 	def new

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,7 +1,7 @@
 class UserMailer < ApplicationMailer
 	def reminder_to_blog_email(user)
 		@user = user
-		@new_post_url = new_user_post_url(@user)
+		@new_post_url = new_post_url(@user)
 
 		mail(to: @user.email, subject: "Time To Blog")
 	end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,7 @@
 class Post < ActiveRecord::Base
   belongs_to :user
 
+  validates :title, presence: true 
   validates :body, length: { minimum: 250 }
 
   def get_frist_sentence

--- a/app/views/layouts/_main_nav_menu_items.html.erb
+++ b/app/views/layouts/_main_nav_menu_items.html.erb
@@ -1,7 +1,7 @@
 <% if current_user %>
   <li><%= link_to("Logout", :logout, method: :delete) %></li>
   <li><%= link_to("Edit", edit_user_path(current_user.id)) %></li>
-  <li><%= link_to("Create Post", new_user_post_path(current_user.id)) %></li>
+  <li><%= link_to("Create Post", new_post_path) %></li>
   <li><%= link_to("Profile", :myprofile) %></li>
 <% else %>
   <li><%= link_to("Sign Up", :signup) %></li>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [@user, @post], html: { class: "materialize-row-form" } do |f| %>
+<%= form_for @post, html: { class: "materialize-row-form" } do |f| %>
 	<% if @post.errors.any? %>
 		<%= render partial: 'shared/error_message', locals: { errors: @post.errors } %>
 	<% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -7,7 +7,7 @@
 
 	<footer class="post-details-footer">
 		<% if current_user && current_user.id == @post.user_id %>
-			<%= link_to("Edit", edit_user_post_path(current_user, @post)) %>
+			<%= link_to("Edit", edit_post_path(@post)) %>
 			<%= link_to"Delete", @post, method: :delete, data: {confirm: "Are you sure you want to delete this post?"} %>
 		<% end %>
 	</footer>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,7 @@ Rails.application.routes.draw do
 
   resources :posts
   resources :user_sessions, only: [ :create ]
-  resources :users, except: [ :index, :new, :show ] do 
-    resources :posts, except: [ :index, :show, :destroy ]
-  end
+  resources :users, except: [ :index, :new, :show ]
 
   get 'signup'          => 'users#new',               as: :signup
   get 'myprofile'       => 'users#show',              as: :myprofile

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root "posts#index"
 
-  resources :posts, only: [ :index, :show, :destroy ]
+  resources :posts
   resources :user_sessions, only: [ :create ]
   resources :users, except: [ :index, :new, :show ] do 
     resources :posts, except: [ :index, :show, :destroy ]

--- a/spec/features/posts_spec.rb
+++ b/spec/features/posts_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Posts", type: :feature do
           vist_create_post
 
           click_on "Submit"
-          expect(page.current_path).to eq("/users/#{user.id}/posts")
+          expect(page.current_path).to eq("/posts")
         end
 
         context "after fixes validation error" do
@@ -61,7 +61,7 @@ RSpec.feature "Posts", type: :feature do
   			
   			login_user_post(user.username, "Pass3word:")
 
-	  		visit edit_user_post_url(user, user.posts.first)
+	  		visit edit_post_url(user.posts.first)
 
 	  		within ".materialize-row-form" do
 	  			fill_in "Title", with: new_post_title

--- a/spec/features/posts_spec.rb
+++ b/spec/features/posts_spec.rb
@@ -13,15 +13,20 @@ RSpec.feature "Posts", type: :feature do
     end
 
   	context "with one post" do
+      subject(:create_proper_post) {
+        within "#new_post" do
+          fill_in "Title", with: Faker::Hacker.say_something_smart
+          fill_in "Body", with: Faker::Lorem.characters
+        end
+
+        click_on "Submit"
+      }
+
   		it "responds with 200" do
         vist_create_post
-  			
-	  		within "#new_post" do
-	  			fill_in "Title", with: Faker::Hacker.say_something_smart
-	  			fill_in "Body", with: Faker::Lorem.characters
-	  		end
 
-	  		click_on "Submit"
+        create_proper_post
+
 	  		expect(page.status_code).to be(200)
 	  	end
 

--- a/spec/features/posts_spec.rb
+++ b/spec/features/posts_spec.rb
@@ -24,6 +24,15 @@ RSpec.feature "Posts", type: :feature do
 	  		click_on "Submit"
 	  		expect(page.status_code).to be(200)
 	  	end
+
+      context "with no title & body" do
+        it "return back to create" do
+          vist_create_post
+
+          click_on "Submit"
+          expect(page.current_path).to eq("/users/#{user.id}/posts")
+        end
+      end
   	end
   end
 

--- a/spec/features/posts_spec.rb
+++ b/spec/features/posts_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Posts", type: :feature do
       login_user_post(user.username, "Pass3word:")
 
       visit root_url
-      click_link "Create Post"
+      find(".main-header-navigation-wrapper-non-mobile-menu").click_link "Create Post"
     end
 
   	context "with one post" do
@@ -21,7 +21,7 @@ RSpec.feature "Posts", type: :feature do
 	  			fill_in "Body", with: Faker::Lorem.characters
 	  		end
 
-	  		click_button "Create Post"
+	  		click_on "Submit"
 	  		expect(page.status_code).to be(200)
 	  	end
   	end
@@ -38,11 +38,11 @@ RSpec.feature "Posts", type: :feature do
 
 	  		visit edit_user_post_url(user, user.posts.first)
 
-	  		within ".edit_post" do
+	  		within ".materialize-row-form" do
 	  			fill_in "Title", with: new_post_title
 	  		end
 
-	  		click_button "Update Post"
+	  		click_on "Submit"
 	  		expect(page.status_code).to be(200)
 
 	  		expect(Post.find(user.posts.first.id).title).to eq new_post_title

--- a/spec/features/posts_spec.rb
+++ b/spec/features/posts_spec.rb
@@ -37,6 +37,17 @@ RSpec.feature "Posts", type: :feature do
           click_on "Submit"
           expect(page.current_path).to eq("/users/#{user.id}/posts")
         end
+
+        context "after fixes validation error" do
+          it "responds with 200" do
+            vist_create_post
+
+            click_on "Submit"
+
+            create_proper_post
+            expect(page.status_code).to be(200)  
+          end
+        end
       end
   	end
   end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe UserMailer, type: :mailer do
   		end
 
   		it "assign @new_post_url" do
-  			expect(mail.body.encoded).to match("/#{user.id}/posts/new")
+  			expect(mail.body.encoded).to match("/posts/new")
   		end
   	end
   end


### PR DESCRIPTION
There is an error where if a user submits the post and had validation errors before the submission it will not find the route. This is because the routes for post was being too restricted and need a user id to create or edit a post. Remove this restriction of the routes for post and remove posting from needing to have a User id to be created since a user will always needs to be need when creating, editing or destroying.

Notice that the Post Feature Test was not working because of the change to Material design fix this in order to test if the user is still be able to submit a post. after my changes.

Also, notice that Post was not being in descending order in Post index which they should made this change as well.
### Other Post Errors
- Fix Flash Alter Missing . After flash.now
