### PR TITLE
Fix Logout Error

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,6 +1,4 @@
 class UserSessionsController < ApplicationController
-  load_and_authorize_resource only: [:destroy]
-
   def new
   	if current_user.present?
   		redirect_back_or_to root_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,6 +9,8 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
 
     if @user.save
+      auto_login(@user)
+
       redirect_to root_path, notice: "Your account has been created"
     else
       flash.now.alert = "Error Creating your account"


### PR DESCRIPTION
Fix the Logout in User Session Controller in which CanCanCan prevented
destroy method from being called when logout was clicked also add in auto login when creating a user.
