### PR TITLE
Add Markdown Render to Post Body

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,8 @@ gem 'font-awesome-sass'
 gem 'whenever', :require => false
 # for used to colour output to the terminal. 
 gem 'colored'
-
+# markdown render parser
+gem 'github-markdown', '~> 0.6.8'
 # rails 12 Factor gem for more detail Heroku Logs and better assests mangement
 gem 'rails_12factor', group: :production
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
       thor (~> 0.14)
     font-awesome-sass (4.3.2.1)
       sass (~> 3.2)
+    github-markdown (0.6.8)
     globalid (0.3.5)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
@@ -267,6 +268,7 @@ DEPENDENCIES
   favorite_things
   figaro
   font-awesome-sass
+  github-markdown (~> 0.6.8)
   jbuilder (~> 2.0)
   jquery-rails
   kaminari

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -64,3 +64,10 @@
 		color: $link-secondary-colour;
 	}
 }
+
+.materialize-row-form-label-markdown-support {
+	@extend .col, .s12;
+
+	text-align: right;
+	font-size: 0.8rem;
+}

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -11,6 +11,6 @@ class Post < ActiveRecord::Base
   end
 
   def render_markdown_post_to_html
-  	"<h3>"
+  	GitHub::Markdown.render_gfm(body)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,9 +5,10 @@ class Post < ActiveRecord::Base
   validates :body, length: { minimum: 250 }
 
   def get_frist_sentence
-  	first_sentence_end_index = body.include?(".") ? body.index('.') : 139
+  	render_plaintext_body = render_markdown_post_to_html(plaintext_instead: true)
+  	first_sentence_end_index = render_plaintext_body.include?(".") ? render_plaintext_body.index('.') : 139
 
-  	body[0..first_sentence_end_index]
+  	render_plaintext_body[0..first_sentence_end_index]
   end
 
   def render_markdown_post_to_html(plaintext_instead: false)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -9,4 +9,8 @@ class Post < ActiveRecord::Base
 
   	body[0..first_sentence_end_index]
   end
+
+  def render_markdown_post_to_html
+  	"<h3>"
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,7 +10,7 @@ class Post < ActiveRecord::Base
   	body[0..first_sentence_end_index]
   end
 
-  def render_markdown_post_to_html
-  	GitHub::Markdown.render_gfm(body)
+  def render_markdown_post_to_html(plaintext_instead: false)
+  	plaintext_instead == false ? GitHub::Markdown.render_gfm(body) : GitHub::Markdown.to_html(body, :plaintext)
   end
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -11,6 +11,9 @@
 	</div>
 
 	<div class="materialize-row">
+		<div class="materialize-row-form-label-markdown-support">
+			<%= link_to("Markdown", "https://guides.github.com/features/mastering-markdown", target: :blank) %> supported
+		</div>
 		<div class="materialize-row-form-one-col">
 			<%= f.text_area :body, cols: 20, row: 40, placeholder: "minimum 250 characters", class: "materialize-textarea" %>
 			<%= f.label :body %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,7 +3,7 @@
 		<%= render 'post_header', local: { post_title_class: "post-details-title", post: @post }  %>
 	</header>
 
-	<p class="post-details-content"><%= @post.render_markdown_post_to_html %></p>
+	<p class="post-details-content"><%= @post.render_markdown_post_to_html.html_safe %></p>
 
 	<footer class="post-details-footer">
 		<% if current_user && current_user.id == @post.user_id %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,7 +3,7 @@
 		<%= render 'post_header', local: { post_title_class: "post-details-title", post: @post }  %>
 	</header>
 
-	<p class="post-details-content"><%= @post.body %></p>
+	<p class="post-details-content"><%= @post.render_markdown_post_to_html %></p>
 
 	<footer class="post-details-footer">
 		<% if current_user && current_user.id == @post.user_id %>

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Post, type: :model do
-  describe "#get_frist_sentence" do
-  	let(:post) { create(:post) } 
+  let(:post) { create(:post) } 
 
+  describe "#get_frist_sentence" do
   	context "just with characters, no period" do
 			subject(:sentence) { post.get_frist_sentence } 
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe Post, type: :model do
       let(:post_with_markdown) { create(:post, body: "### #{Faker::Hacker.say_something_smart}\n*#{Faker::Lorem.sentences(14)}*") }
       subject(:sentence_with_markdown) { post_with_markdown.get_frist_sentence } 
 
+      it "return string with no markdown tags" do
+        expect(sentence_with_markdown.include?("###")).to be(false)
+      end
+
       it "return a plain text version with a sentence" do
         expect(sentence_with_markdown.index('.')).to eq((sentence_with_markdown.length - 1))
       end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Post, type: :model do
     let(:post_with_markdown) { create(:post, body: "### #{Faker::Hacker.say_something_smart}\n*#{Faker::Lorem.sentences}* \n**#{Faker::Lorem.words(19)}**\n#{Faker::Internet.url}") } 
 
     context "post with markdown body" do
-      it "return html" do
+      it "return string includes <h3>" do
         expect(post_with_markdown.render_markdown_post_to_html.include?("<h3>")).to be(true)
       end
     end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe Post, type: :model do
   			expect(sentence.index('.')).to eq((sentence.length - 1))
   		end
   	end
+
+    context "with markdown body and proper sentence" do
+      let(:post_with_markdown) { create(:post, body: "### #{Faker::Hacker.say_something_smart}\n*#{Faker::Lorem.sentences(14)}*") }
+      subject(:sentence_with_markdown) { post_with_markdown.get_frist_sentence } 
+
+      it "return a plain text version with a sentence" do
+        expect(sentence_with_markdown.index('.')).to eq((sentence_with_markdown.length - 1))
+      end
+    end
   end
 
   describe "#render_markdown_post_to_html" do

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe Post, type: :model do
       it "return string includes <h3>" do
         expect(post_with_markdown.render_markdown_post_to_html.include?("<h3>")).to be(true)
       end
+
+      it "return string includes link" do
+        expect(post_with_markdown.render_markdown_post_to_html.include?("<a href=")).to be(true)
+      end
     end
   end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -47,5 +47,11 @@ RSpec.describe Post, type: :model do
         expect(post_with_markdown.render_markdown_post_to_html.include?("<a href=")).to be(true)
       end
     end
+
+    context "post without markdown body" do
+      it "return string with p tag around it" do
+        expect(post.render_markdown_post_to_html).to eq("<p>#{post.body}</p>\n")
+      end
+    end
   end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Post, type: :model do
   end
 
   describe "#render_markdown_post_to_html" do
-    let(:post_with_markdown) { create(:post, body: "### #{Faker::Hacker.say_something_smart}\n*#{Faker::Lorem.sentences}* \n**#{Faker::Lorem.words(19)}**\n#{Faker::Internet.url}") } 
+    let(:post_with_markdown) { create(:post, body: "### #{Faker::Hacker.say_something_smart}\n*#{Faker::Lorem.sentences}* \n**#{Faker::Lorem.words(19)}**\n#{Faker::Internet.url}") }
 
     context "post with markdown body" do
       it "return string includes <h3>" do
@@ -45,6 +45,10 @@ RSpec.describe Post, type: :model do
 
       it "return string includes link" do
         expect(post_with_markdown.render_markdown_post_to_html.include?("<a href=")).to be(true)
+      end
+
+      it "return plain text version" do
+        expect(post_with_markdown.render_markdown_post_to_html(plaintext_instead: true).include?("<em>")).to be(false)
       end
     end
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -34,4 +34,14 @@ RSpec.describe Post, type: :model do
   		end
   	end
   end
+
+  describe "#render_markdown_post_to_html" do
+    let(:post_with_markdown) { create(:post, body: "### #{Faker::Hacker.say_something_smart}\n*#{Faker::Lorem.sentences}* \n**#{Faker::Lorem.words(19)}**\n#{Faker::Internet.url}") } 
+
+    context "post with markdown body" do
+      it "return html" do
+        expect(post_with_markdown.render_markdown_post_to_html.include?("<h3>")).to be(true)
+      end
+    end
+  end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe Post, type: :model do
         expect(sentence_with_markdown.include?("###")).to be(false)
       end
 
+      it "return string with no HTML tags" do
+        expect(sentence_with_markdown.include?("<h3>")).to be(false)
+      end
+
       it "return a plain text version with a sentence" do
         expect(sentence_with_markdown.index('.')).to eq((sentence_with_markdown.length - 1))
       end


### PR DESCRIPTION
Add Markdown base from GitHub markdown language to display HTML tags without having to know HTML tags also allow HTML tags to be render in Post show.

Because a gem called GItHub Markdown has been added to the application you will need to run `bundle install`
