### PR TITLE
Fix Model To View Methods

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -22,6 +22,7 @@ class PostsController < ApplicationController
 
 	def show
 		@post = Post.find(params[:id])
+    @markdown_post_body = @post.render_markdown_post_to_html.html_safe
 	end
 
 	def edit

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,2 +1,5 @@
 module PostsHelper
+	def display_summary(post)
+		post.get_frist_sentence
+	end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -7,7 +7,7 @@
       	<div class="post-row-card-content">
       		<%= render 'post_header', local: { post_title_class: "post-row-card-title", post: post }  %>
 
-					<p><%= post.get_frist_sentence %></p>
+					<p><%= display_summary(post) %></p>
 				</div>
 
 				<div class="post-row-card-action">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,7 +3,7 @@
 		<%= render 'post_header', local: { post_title_class: "post-details-title", post: @post }  %>
 	</header>
 
-	<p class="post-details-content"><%= @post.render_markdown_post_to_html.html_safe %></p>
+	<p class="post-details-content"><%= @markdown_post_body %></p>
 
 	<footer class="post-details-footer">
 		<% if current_user && current_user.id == @post.user_id %>

--- a/spec/helpers/posts_helper_spec.rb
+++ b/spec/helpers/posts_helper_spec.rb
@@ -11,5 +11,19 @@ require 'rails_helper'
 #   end
 # end
 RSpec.describe PostsHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
+	describe "#display_post_summary" do
+		let(:post) { create(:post) }
+
+		context "no summary text use first sentence" do
+			it "return a sentence" do
+				post.body = Faker::Lorem.sentence(14)
+
+				expect(helper.display_summary(post)).to eq(post.get_frist_sentence)
+			end
+
+			it "return 140 characters" do
+  			expect(helper.display_summary(post).length).to eq(140)
+  		end
+		end
+	end
 end


### PR DESCRIPTION
Move any model method from the view and use the controller to use those methods instead because this is proper MVC design pattern since the controller is the one that calls methods from the model and displays the results to the view. In this case render_markdown_post_to_html is being called from the view instead of the controller which is not proper.
