### PR TITLE
Fix Sass Styles

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -22,10 +22,6 @@
 	}	
 }
 
-.materialize-form {
-	@extend .row;
-}
-
 .materialize-row {
 	@extend .row;
 }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -31,14 +31,16 @@
 }
 
 .materialize-row-form {
-	@extend .col, .s12;
-
 	.materialize-row-form-one-col {
-		@extend .input-field, .col, .s12;
+		@extend .input-field;
+		@extend .col;
+		@extend .s12;
 	}
 
 	.materialize-row-form-two-col {
-		@extend .input-field, .col, .s6;
+		@extend .input-field;
+		@extend .col;
+		@extend .s6;
 	}
 
 	[type="checkbox"]:checked {

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -10,5 +10,3 @@ $link-secondary-colour: #FFF;
 // Checkboxes
 
 $radio-fill-colour: $secondary-colour !default;
-
-@import "materialize";


### PR DESCRIPTION
Remove unnecessary Sass extends which is causing some of the styles to be huge and possible unmanageable also remove duplicate materialize Sass import.
