### PR TITLE
Add Publish Date To Post Model  & Query

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
 	def index
-		@posts = Post.all.order(id: :desc).page(params[:page])
+		@posts = Post.display_and_order_by_publish_date.page(params[:page])
 	end
 
 	def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,7 +43,7 @@ class UsersController < ApplicationController
 
   def feed
     @user = User.find(params[:id])
-    @posts = @user.posts.order(id: :desc)
+    @posts = @user.posts.display_and_order_by_publish_date
 
     respond_to do |format|
       format.atom  { render layout: false }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,7 +7,7 @@ class Post < ActiveRecord::Base
   validates :body, length: { minimum: 250 }
 
   def self.display_and_order_by_publish_date
-    Post.all.where('publish_date IS NOT NULL').where('publish_date <= ?', Time.now)
+    Post.all.where('publish_date IS NOT NULL').where('publish_date <= ?', Time.now).order(publish_date: :desc)
   end
 
   def get_frist_sentence

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,6 +6,10 @@ class Post < ActiveRecord::Base
   validates :summary, length: { maximum: 140 }
   validates :body, length: { minimum: 250 }
 
+  def self.display_and_order_by_publish_date
+    Post.all.where('publish_date != null')
+  end
+
   def get_frist_sentence
   	render_plaintext_body = render_markdown_post_to_html(plaintext_instead: true)
   	first_sentence_end_index = render_plaintext_body.include?(".") ? render_plaintext_body.index('.') : 139

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,7 +7,7 @@ class Post < ActiveRecord::Base
   validates :body, length: { minimum: 250 }
 
   def self.display_and_order_by_publish_date
-    Post.all.where('publish_date != null')
+    Post.all.where('publish_date IS NOT NULL').where('publish_date <= ?', Time.now)
   end
 
   def get_frist_sentence

--- a/app/views/posts/_post_header.html.erb
+++ b/app/views/posts/_post_header.html.erb
@@ -3,7 +3,7 @@
 by <%= local[:post].user.username %>
 <br>
 <i class="post-details-date">
-	<%= time_tag local[:post].created_at, pubdate: true do %>
-		<%= local[:post].created_at.strftime("%B %d, %Y")  %>
+	<%= time_tag local[:post].publish_date, pubdate: true do %>
+		<%= local[:post].publish_date.strftime("%B %d, %Y")  %>
 	<% end %>
 </i>

--- a/db/migrate/20150702144502_add_publish_date_to_post.rb
+++ b/db/migrate/20150702144502_add_publish_date_to_post.rb
@@ -1,0 +1,5 @@
+class AddPublishDateToPost < ActiveRecord::Migration
+  def change
+    add_column :posts, :publish_date, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150604134335) do
+ActiveRecord::Schema.define(version: 20150702144502) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,9 +31,10 @@ ActiveRecord::Schema.define(version: 20150604134335) do
     t.string   "title"
     t.text     "body"
     t.integer  "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
     t.text     "summary"
+    t.datetime "publish_date"
   end
 
   add_index "posts", ["user_id"], name: "index_posts_on_user_id", using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,7 +26,8 @@ user = User.create!(
 50.times do |current_number|
 	user.posts << Post.create!(
 		title: Faker::Hacker.say_something_smart,
-		body: (current_number % 2) == 0 ? Faker::Lorem.paragraphs((8..32).to_a.sample).join("<br><br>") : Faker::Lorem.sentences((16..64).to_a.sample).join(" ")
+		body: (current_number % 2) == 0 ? Faker::Lorem.paragraphs((8..32).to_a.sample).join("<br><br>") : Faker::Lorem.sentences((16..64).to_a.sample).join(" "),
+		publish_date: Faker::Date.between(5.days.ago, 5.days.from_now)
 	)
 
 	5.times { user.posts.last.comments << Comment.create!(body: Faker::Lorem.sentences((8..16).to_a.sample).join(" "), user_id: user.id) }

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     title 	Faker::Hacker.say_something_smart
 		body 		Faker::Lorem.characters
 		summary Faker::Lorem.sentence
+		publish_date { Faker::Date.between(5.days.ago, 5.days.from_now) }
 		user
 
 		factory :post_with_comments do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+require "cancan/matchers"
+
+RSpec.describe Ability, type: :model do
+  describe "#user" do
+    subject(:ability){ Ability.new(user) }
+    let(:user_with_posts){ create(:user_with_posts) }
+
+    context "with no post" do
+    	let(:user){ nil }
+
+			it "expect not have abilities update or destory post" do
+				# expect(should not_have_abilities([:update, :destroy], user))
+      end
+    end
+	end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -102,5 +102,13 @@ RSpec.describe Post, type: :model do
         expect(Post.display_and_order_by_publish_date.where(user: last_user_be_created).count).to be(1)
       end
     end
+
+    context "order by publish_date from latest to oldest" do
+      it "return first post publish date be greater then last post publish date" do
+        posts = Post.display_and_order_by_publish_date
+
+        expect(posts.first.publish_date).to be > posts.last.publish_date
+      end
+    end
   end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -86,5 +86,11 @@ RSpec.describe Post, type: :model do
         expect(post_with_publish_date_nil).to be(nil)
       end
     end
+
+    context "when publish date is in the now" do
+      it "return greater then 0" do
+        expect(Post.display_and_order_by_publish_date.count).to be > 0
+      end
+    end
   end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -92,5 +92,15 @@ RSpec.describe Post, type: :model do
         expect(Post.display_and_order_by_publish_date.count).to be > 0
       end
     end
+
+    context "when publish date is only for one user" do
+      let!(:post_different_user) { create(:post, publish_date: 3.days.ago) }
+
+      it "return 1" do
+        last_user_be_created = Post.last.user
+
+        expect(Post.display_and_order_by_publish_date.where(user: last_user_be_created).count).to be(1)
+      end
+    end
   end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -75,4 +75,16 @@ RSpec.describe Post, type: :model do
       end
     end
   end
+
+  describe "#display_and_order_by_publish_date" do
+    let!(:post) { create(:user_with_posts, num_posts: 25) }
+
+    context "when publish date is nil" do
+      it "return nil" do
+        post_with_publish_date_nil = Post.display_and_order_by_publish_date.find { |post| post.publish_date == nil }
+
+        expect(post_with_publish_date_nil).to be(nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add publish date to the Post model and update the queries to display them. You will need to run `rake db:migrate` to get the latest update to the Post model. Because of this the Publish Date is now being used in the Post header instead of created at
