### PR TITLE
Update Publish Date Column, Be Not Nil On Default

### DIFF
--- a/db/migrate/20150702191102_update_publish_date_in_post_to_be_not_nil.rb
+++ b/db/migrate/20150702191102_update_publish_date_in_post_to_be_not_nil.rb
@@ -1,0 +1,12 @@
+class UpdatePublishDateInPostToBeNotNil < ActiveRecord::Migration
+  def change
+  	change_column :posts, :publish_date, :timestamp, :default => Time.now
+
+  	posts_with_no_publish_date = Post.where(publish_date: nil)
+
+  	posts_with_no_publish_date.each do |post|
+  		post.publish_date = Time.now
+  		post.save
+  	end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150702144502) do
+ActiveRecord::Schema.define(version: 20150702191102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,10 +31,10 @@ ActiveRecord::Schema.define(version: 20150702144502) do
     t.string   "title"
     t.text     "body"
     t.integer  "user_id"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",                                   null: false
+    t.datetime "updated_at",                                   null: false
     t.text     "summary"
-    t.datetime "publish_date"
+    t.datetime "publish_date", default: '2015-07-02 19:17:04'
   end
 
   add_index "posts", ["user_id"], name: "index_posts_on_user_id", using: :btree


### PR DESCRIPTION
Update the publish date column to be not nil when it is created. Also
this migration will update existing data to have their publish date to
not be nil either. 

You will need to run `rake db:migration` to update your local database
