### PR TITLE
Add Publish Date To Post Create

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -71,3 +71,8 @@
 	text-align: right;
 	font-size: 0.8rem;
 }
+
+.publish-date-selectors {
+	display: initial;
+	width: initial;
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -57,6 +57,7 @@ class PostsController < ApplicationController
       :title, 
       :body,
       :summary,
+      :publish_date,
       :user_id
     )
   end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -28,7 +28,7 @@
 	<div class="materialize-row">
 		<%= f.label :publish_date %>
 		<div class="materialize-row-form-one-col">
-			<%= f.datetime_select :publish_date, { ampm: true, order: [:hour, :minute, :month, :day, :year] }, class: "browser-default" %>
+			<%= f.datetime_select :publish_date, { ampm: true, order: [:hour, :minute, :month, :day, :year] }, class: "publish-date-selectors" %>
 		</div>
 	</div>
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -25,6 +25,10 @@
 		<%= f.label :summary %>
 	</div>
 
+	<div class="materialize-row-form-one-col">
+		<%= f.datetime_select :publish_date, { ampm: true }, class: "browser-default" %>
+	</div>
+
 	<div class="materialize-row">
 		<div class="materialize-row-form-one-col">
 			<%= f.button "Submit", { class: "materialize-row-form-submit", type: "submit" } %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -25,8 +25,11 @@
 		<%= f.label :summary %>
 	</div>
 
-	<div class="materialize-row-form-one-col">
-		<%= f.datetime_select :publish_date, { ampm: true }, class: "browser-default" %>
+	<div class="materialize-row">
+		<%= f.label :publish_date %>
+		<div class="materialize-row-form-one-col">
+			<%= f.datetime_select :publish_date, { ampm: true, order: [:hour, :minute, :month, :day, :year] }, class: "browser-default" %>
+		</div>
 	</div>
 
 	<div class="materialize-row">

--- a/db/migrate/20150703154303_update_default_value_publish_date_in_post.rb
+++ b/db/migrate/20150703154303_update_default_value_publish_date_in_post.rb
@@ -1,0 +1,5 @@
+class UpdateDefaultValuePublishDateInPost < ActiveRecord::Migration
+  def change
+		execute "ALTER TABLE posts ALTER COLUMN publish_date SET DEFAULT CURRENT_TIMESTAMP" 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150702191102) do
+ActiveRecord::Schema.define(version: 20150703154303) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,10 +31,10 @@ ActiveRecord::Schema.define(version: 20150702191102) do
     t.string   "title"
     t.text     "body"
     t.integer  "user_id"
-    t.datetime "created_at",                                   null: false
-    t.datetime "updated_at",                                   null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
     t.text     "summary"
-    t.datetime "publish_date", default: '2015-07-02 19:17:04'
+    t.datetime "publish_date", default: "now()"
   end
 
   add_index "posts", ["user_id"], name: "index_posts_on_user_id", using: :btree

--- a/spec/features/posts_spec.rb
+++ b/spec/features/posts_spec.rb
@@ -19,6 +19,9 @@ RSpec.feature "Posts", type: :feature do
         within "#new_post" do
           fill_in "Title", with: Faker::Hacker.say_something_smart
           fill_in "Body", with: Faker::Lorem.characters
+
+          select(3.hours.from_now.strftime("%I %p"), from: :post_publish_date_4i)
+          select(Time.now.strftime("%M"), from: :post_publish_date_5i)
         end
 
         click_submit
@@ -31,6 +34,17 @@ RSpec.feature "Posts", type: :feature do
 
 	  		expect(page.status_code).to be(200)
 	  	end
+
+      it "responds with 200 with publish 3 hours from now" do
+        vist_create_post
+
+        create_proper_post
+
+        latest_post = Post.last
+
+        expect(page.status_code).to be(200)
+        expect(latest_post.publish_date.strftime("%I:%M %p")).to eq(3.hours.from_now.strftime("%I:%M %p"))
+      end
 
       context "with no title & body" do
         it "return back to create" do


### PR DESCRIPTION
Add Publish date form into the post create. Also because the default date is set when the migration happen the publish date will always use that date when the post create view is loaded. Change the default value for publish date to be whatever the current date and time is
