### PR TITLE
Fix Post Serializer Using Belongs To For User

### DIFF
--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -3,7 +3,7 @@ class PostSerializer < ActiveModel::Serializer
 
   attributes :title, :body, :summary, :created_at, :url
 
-  belongs_to :user
+  has_one :user
 
   def url
   	post_url(object)


### PR DESCRIPTION
Fix Post Serializer using belongs to instead of has one for the user
because serializer is unable to make an association with belongs to.
