### PR TITLE
Add New Relic Gem & Config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,9 @@ group :production do
 
 	# adds Heroku Addon Postmark in order to use SMTP on the produciton server
 	gem 'postmark-rails'
+
+	# add New Relic Gem to montior of application from dashboard
+	gem 'newrelic_rpm'
 end
 
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,7 @@ GEM
     multi_json (1.11.0)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
+    newrelic_rpm (3.12.1.298)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     oauth (0.4.7)
@@ -285,6 +286,7 @@ DEPENDENCIES
   letter_opener
   materialize-sass
   modernizr-rails (~> 2.7.1)
+  newrelic_rpm
   pg
   postmark-rails
   pry-byebug

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,0 +1,49 @@
+#
+# This file configures the New Relic Agent.  New Relic monitors Ruby, Java,
+# .NET, PHP, Python and Node applications with deep visibility and low
+# overhead.  For more information, visit www.newrelic.com.
+#
+# Generated July 06, 2015
+# 
+# This configuration file is custom generated for app37045042@heroku.com
+#
+# For full documentation of agent configuration options, please refer to
+# https://docs.newrelic.com/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration
+
+common: &default_settings
+  # Required license key associated with your New Relic account.
+  license_key: ENV['NEW_RELIC_LICENSE_KEY']
+
+  # Your application name. Renaming here affects where data displays in New
+  # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications
+  app_name: Blog a Day
+
+  # To disable the agent regardless of other settings, uncomment the following:
+  # agent_enabled: false
+
+  # Logging level for log/newrelic_agent.log
+  log_level: info
+
+
+# Environment-specific settings are in this section.
+# RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.
+# If your application has other named environments, configure them here.
+development:
+  <<: *default_settings
+  app_name: Blog a Day (Development)
+
+  # NOTE: There is substantial overhead when running in developer mode.
+  # Do not use for production or load testing.
+  developer_mode: true
+
+test:
+  <<: *default_settings
+  # It doesn't make sense to report to New Relic from automated test runs.
+  monitor_mode: false
+
+staging:
+  <<: *default_settings
+  app_name: Blog a Day (Staging)
+
+production:
+  <<: *default_settings


### PR DESCRIPTION
Add the gem New Relic to monitor the application from the New Relic site. Also add in the settings for New Relic in order to be configure on New Relic site.
