### PR TITLE
Fix Daily Reminder Schedule Tasks, Be Least Bridle

### DIFF
--- a/lib/tasks/schedule_reminder_to_blog.rake
+++ b/lib/tasks/schedule_reminder_to_blog.rake
@@ -1,7 +1,7 @@
 namespace :schedule_reminder do
 	desc "Send out reminders to users to blog"
 	task to_blog: :environment do
-		users = User.where("daily_reminder = ? AND enable_daily_reminder = ?", Time.now.at_beginning_of_hour, true)
+		users = User.where(daily_reminder: Time.now.at_beginning_of_hour..Time.now.at_end_of_hour).where(enable_daily_reminder: true)
 
 		users.each do |user|
 			UserMailer.reminder_to_blog_email(user).deliver_later


### PR DESCRIPTION
Fix the Daily Reminder Schedule Tasks to be least bridle because the
scheduler may not activated on the hour. If the server that the app is
on is busy with other items thus the user would not receive an email for
that day.
