### PR TITLE
Add Link To User Show From Post Index

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,7 +34,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = current_user
+    @user = User.find(params[:id])
     @posts = @user.posts.order(id: :desc).page(params[:page])
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,7 +35,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @posts = @user.posts.order(id: :desc).page(params[:page])
+    @posts = @user.posts.display_and_order_by_publish_date.page(params[:page])
   end
 
   def destroy

--- a/app/views/layouts/_main_nav_menu_items.html.erb
+++ b/app/views/layouts/_main_nav_menu_items.html.erb
@@ -1,6 +1,6 @@
 <% if current_user %>
   <li><%= link_to("Logout", :logout, method: :delete) %></li>
-  <li><%= link_to("Edit", edit_user_path(current_user.id)) %></li>
+  <li><%= link_to("Edit", edit_user_path(current_user)) %></li>
   <li><%= link_to("Create Post", new_post_path) %></li>
   <li><%= link_to("Profile", profile_path(current_user)) %></li>
 <% else %>

--- a/app/views/layouts/_main_nav_menu_items.html.erb
+++ b/app/views/layouts/_main_nav_menu_items.html.erb
@@ -2,7 +2,7 @@
   <li><%= link_to("Logout", :logout, method: :delete) %></li>
   <li><%= link_to("Edit", edit_user_path(current_user.id)) %></li>
   <li><%= link_to("Create Post", new_post_path) %></li>
-  <li><%= link_to("Profile", :profile) %></li>
+  <li><%= link_to("Profile", profile_path(current_user)) %></li>
 <% else %>
   <li><%= link_to("Sign Up", :signup) %></li>
   <li><%= link_to("Login", :login) %></li>

--- a/app/views/posts/_post_header.html.erb
+++ b/app/views/posts/_post_header.html.erb
@@ -1,6 +1,6 @@
 <h4 class="<%= local[:post_title_class] %>"><%= local[:post].title %></h4>
 
-by <%= local[:post].user.username %>
+by <%= link_to(local[:post].user.username, profile_path(local[:post].user)) %>
 <br>
 <i class="post-details-date">
 	<%= time_tag local[:post].publish_date, pubdate: true do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   end
 
   get 'signup'          => 'users#new',               as: :signup
-  get 'profile'         => 'users#show',              as: :profile
+  get 'profile/:id'     => 'users#show',              as: :profile
   get 'login'           => 'user_sessions#new',       as: :login
   delete 'logout'       => 'user_sessions#destroy',   as: :logout
 


### PR DESCRIPTION
Add a link to the User show view from Post index view in order to do this updated the routes to use params id for the profile route. Because the profile is meant to showcase the users the activated of the user on the application. Currently it is not doing this which defeats the whole propose.

Also in order to be consistent remove the `.id` from Edit in header and add in `.display_and_order_by_publish_date` to the posts in user#show.
